### PR TITLE
Select resources on which to provision based on tags

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__class__.yaml
@@ -133,10 +133,30 @@ object:
       max_time: 
   - field:
       aetype: method
-      name: redhat
+      name: placement_filters
       display_name: 
       datatype: string
       priority: 7
+      owner: 
+      default_value: 
+      substitute: true
+      message: "*"
+      visibility: 
+      collect: 
+      scope: 
+      description: 
+      condition: 
+      on_entry: 
+      on_exit: 
+      on_error: 
+      max_retries: 
+      max_time: 
+  - field:
+      aetype: method
+      name: redhat
+      display_name: 
+      datatype: string
+      priority: 8
       owner: 
       default_value: 
       substitute: true
@@ -156,7 +176,7 @@ object:
       name: vmware
       display_name: 
       datatype: string
-      priority: 8
+      priority: 9
       owner: 
       default_value: 
       substitute: true
@@ -176,7 +196,7 @@ object:
       name: microsoft
       display_name: 
       datatype: string
-      priority: 9
+      priority: 10
       owner: 
       default_value: 
       substitute: true
@@ -196,7 +216,7 @@ object:
       name: redhat_customize
       display_name: 
       datatype: string
-      priority: 10
+      priority: 11
       owner: 
       default_value: 
       substitute: true
@@ -216,7 +236,7 @@ object:
       name: vmware_customize
       display_name: 
       datatype: string
-      priority: 11
+      priority: 12
       owner: 
       default_value: 
       substitute: true
@@ -236,7 +256,7 @@ object:
       name: microsoft_customize
       display_name: 
       datatype: string
-      priority: 12
+      priority: 13
       owner: 
       default_value: 
       substitute: true

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.rb
@@ -1,0 +1,41 @@
+# Filter clusters, hosts, and datastores based on tags
+# The only expected output from this method is a hash of tags. Each tag name can be mapped to either a single value or an array
+# If a single value is passed for a tag, that value must be matched on a resource for it to be selected during placement
+# If an array of values is passed, any one of those values must match on a resource
+#
+# NOTE: Intended to be overriden by implementers.
+#
+# SETS
+#   EVM OBJECT
+#     'placement_filters' - Hash of tag names to values that must exist for a resource to be selected in the placement process
+@DEBUG = false
+
+# IMPLEMENTERS: Update with business logic
+# @return hash of tags to values
+def get_placement_filters
+  filters = {}
+  
+  return filters
+end
+
+# IMPLEMENTERS: DO NOT MODIFY
+#
+# Log an error and exit.
+#
+# @param msg Message to error with
+def error(msg)
+  $evm.log(:error, msg)
+  $evm.root['ae_result'] = 'error'
+  $evm.root['ae_reason'] = msg.to_s
+  exit MIQ_STOP
+end
+
+# IMPLEMENTERS: DO NOT MODIFY
+#
+# Set the filters on $evm.object
+begin
+  placement_filters = get_placement_filters
+  $evm.log(:info, "Setting placement filters to "+placement_filters.to_s) if @DEBUG    
+  
+  $evm.object['placement_filters'] = placement_filters
+end

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.rb
@@ -13,7 +13,13 @@
 # IMPLEMENTERS: Update with business logic
 # @return hash of tags to values
 def get_placement_filters
-  filters = {}
+  prov = $evm.root["miq_provision"]
+  user = prov.miq_request.requester
+  error("User not specified") if user.nil?
+  normalized_ldap_group = user.normalized_ldap_group.gsub(/\W/,'_')
+
+  #By default, look for either prov_scope all or equal to the requesting user's ldap group
+  filters = {"prov_scope"=>["all",normalized_ldap_group]}
   
   return filters
 end

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.yaml
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/placement_filters.yaml
@@ -1,0 +1,12 @@
+---
+object_type: method
+version: 1.0
+object:
+  attributes:
+    name: placement_filters
+    display_name: 
+    description: 
+    scope: instance
+    language: ruby
+    location: inline
+  inputs: []

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_drs_cluster_best_fit_with_scope.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_drs_cluster_best_fit_with_scope.rb
@@ -62,22 +62,18 @@ begin
   prov = $evm.root["miq_provision"]
   vm = prov.vm_template
   error("VM not specified") if vm.nil?
-  user = prov.miq_request.requester
-  error("User not specified") if user.nil?
   ems  = vm.ext_management_system
   error("EMS not found for VM:<#{vm.name}>") if ems.nil?
-  tags = get_param(:placement_filters)
-  $evm.log(:info,"Additional placement filters: "+tags.to_s) if @DEBUG
   
   # Get Tags that are in scope
   # Default is to look for Hosts and Datastores tagged with prov_scope = All or match to Group
-  # Will also look for any tags specified in the placement_filters hash
-  normalized_ldap_group = user.normalized_ldap_group.gsub(/\W/,'_')
-  tags["prov_scope"] = ["all", normalized_ldap_group]
+  # Will also look for any tags specified in placement_filters
+  tags = get_param(:placement_filters)
+  $evm.log(:info,"Additional placement filters: "+tags.to_s) if @DEBUG
   
   $evm.log(:info, "Tags: "+tags.to_s)
 
-  $evm.log("info", "VM=<#{vm.name}>, Space Required=<#{vm.provisioned_storage}>, group=<#{user.normalized_ldap_group}>")
+  $evm.log("info", "VM=<#{vm.name}>, Space Required=<#{vm.provisioned_storage}>, placement filters=<#{tags.to_s}>")
   
   #############################
   # STORAGE LIMITATIONS

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_drs_cluster_best_fit_with_scope.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/__methods__/vmware_drs_cluster_best_fit_with_scope.rb
@@ -67,7 +67,7 @@ begin
   
   # Get Tags that are in scope
   # Default is to look for Hosts and Datastores tagged with prov_scope = All or match to Group
-  # Will also look for any tags specified in placement_filters
+  # This behavior can be overridden by modifying the hash returned in get_placement_filters
   tags = get_param(:placement_filters)
   $evm.log(:info,"Additional placement filters: "+tags.to_s) if @DEBUG
   

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/default.yaml
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Placement.class/default.yaml
@@ -8,6 +8,8 @@ object:
     inherits: 
     description: 
   fields:
+  - placement_filters:
+      value: placement_filters
   - redhat:
       value: redhat_best_placement_with_scope
   - vmware:


### PR DESCRIPTION
This PR creates a new method, to be overridden by users, which allows the creation and setting of a tag hash. This tag hash is then used during the placement process to determine which clusters, hosts, and datastores are valid provisioning targets for a given VM.