### PR TITLE
Fix reference to undefined variable in error handling code

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_update.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_update.rb
@@ -259,7 +259,7 @@ begin
   unless to_email_addresses.blank?
     send_vm_provision_complete_email(prov, to_email_addresses, from_email_address, update_message, vm_current_provision_ae_result, cfme_hostname)
   else
-    warn_message = "No one to send VM Provision Update email to. Request: #{request.id}"
+    warn_message = "No one to send VM Provision Update email to. Request: #{prov.miq_provision_request.id}"
     $evm.log(:warn, warn_message)
     $evm.create_notification(:level   => 'warning',
                              :message => warn_message)


### PR DESCRIPTION
miqprovision_update was trying to use an undefined "request" variable. Corrected this.