### PR TITLE
Correctly escape messages for HTML characters in provisioning emails

### DIFF
--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_update.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/Email.class/__methods__/miqprovision_update.rb
@@ -4,6 +4,7 @@
 # instances to standerdize what email updates look like.
 #
 @DEBUG = false
+require 'cgi'
 
 PROVISIONING_TELEMETRY_PREFIX = "Provisioning: Telemetry:"
 
@@ -204,7 +205,7 @@ def send_vm_provision_update_email(prov, to, from, update_message, vm_current_pr
   body += "<tr><td><b>State</b></td><td>#{state}</td></tr>"
   body += "<tr><td><b>Status</b></td><td><span style='#{status_style}'>#{status}</span></td></tr>"
   body += "<tr><td><b>Step</b></td><td>#{$evm.root['ae_state']}</td></tr>" unless $evm.root['ae_state'].nil?
-  body += "<tr><td><b>Message</b></td><td>#{update_message}</td></tr>"
+  body += "<tr><td><b>Message</b></td><td>#{CGI::escapeHTML(update_message)}</td></tr>"
   body += "<tr><td><b>CloudForms Provisioning Request ID</b></td><td><a href='https://#{cfme_hostname}/miq_request/show/#{prov.miq_provision_request.id}'>#{prov.miq_provision_request.id}</a></td></tr>"
   body += "</table>"
   body += "<br />"

--- a/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/process_telemetry_data.rb
+++ b/Automate/RedHatConsulting_Utilities/Infrastructure/VM/Provisioning/StateMachines/Methods.class/__methods__/process_telemetry_data.rb
@@ -23,7 +23,7 @@ end
 #
 # @return Duration in HH:MM:SS between to times, or Unknown, if any time is nil
 def get_duration(start_time, end_time)
-  $evm.log(:info, "get_duration: START: { :start_time => #{start_time}, :end_time => #{:end_time} }") if @DEBUG
+  $evm.log(:info, "get_duration: START: { :start_time => #{start_time}, :end_time => #{end_time} }") if @DEBUG
   duration = 'Unknown'
   
   start_time = $evm.get_state_var(start_time) if start_time.class == Symbol
@@ -34,8 +34,8 @@ def get_duration(start_time, end_time)
   else
     duration = 'Unknown'
   end
-  
-  $evm.log(:info, "get_duration: END: { :duration => #{duration}, :start_time => #{start_time}, :end_time => #{:end_time} }") if @DEBUG
+
+  $evm.log(:info, "get_duration: END: { :duration => #{duration}, :start_time => #{start_time}, :end_time => #{end_time} }") if @DEBUG
   return duration
 end
 

--- a/Automate/RedHatConsulting_Utilities/Service/Provisioning/Email.class/__methods__/serviceprovision_update.rb
+++ b/Automate/RedHatConsulting_Utilities/Service/Provisioning/Email.class/__methods__/serviceprovision_update.rb
@@ -4,6 +4,7 @@
 # instances to standerdize what email updates look like.
 #
 @DEBUG = false
+require 'cgi'
 
 PROVISIONING_TELEMETRY_PREFIX = "Provisioning: Telemetry:"
 
@@ -204,7 +205,7 @@ def send_service_provision_update_email(request, to, from, update_message, cfme_
   body += "<tr><td><b>State</b></td><td>#{state}</td></tr>"
   body += "<tr><td><b>Status</b></td><td><span style='#{status_style}'>#{status}</span></td></tr>"
   body += "<tr><td><b>Step</b></td><td>#{$evm.root['ae_state']}</td></tr>" unless $evm.root['ae_state'].nil?
-  body += "<tr><td><b>Message</b></td><td>#{update_message}</td></tr>"
+  body += "<tr><td><b>Message</b></td><td>#{CGI::escapeHTML(update_message)}</td></tr>"
   body += "<tr><td><b>VM Requests</b></td><td>#{vm_requests}</td></tr>"
   body += "<tr><td><b>Approval State</b></td><td>#{request.approval_state.capitalize}</td></tr>"
   body += "<tr><td><b>Approver Notes</b></td><td>#{request.reason}</td></tr>"
@@ -262,7 +263,7 @@ def send_service_provision_update_email(request, to, from, update_message, cfme_
     body += "<td>#{vm_task.id}</td>"
     
     # add last task message
-    body += "<td>#{vm_task.message}</td>"
+    body += "<td>#{CGI::escapeHTML(vm_task.message)}</td>"
     
     body += "</tr>"
   end


### PR DESCRIPTION
This PR solves the problem of greater than and less than symbols showing up in the message of an email and being interpreted as HTML.